### PR TITLE
Include the `lint`, `check`, and `prepare` commands as part of the action

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM grafana/cortextool:v2.1.0
+FROM grafana/cortextool:v0.2.2
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM grafana/cortextool:v0.1.4
+FROM grafana/cortextool:v2.1.0
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Reconcile the differences with the sourced rules and the rules currently running
 
 ### `lint`
 
-Lints a rules file(s). The linter's aim is not to verify correctness but just YAML and PromQL expression formatting within the rule file(s). The linting happens in-place within the specified file(s). Does not interact with your Cortex cluster.
+Lints a rules file(s). The linter's aim is not to verify correctness but to fix YAML and PromQL expression formatting within the rule file(s). The linting happens in-place within the specified file(s). Does not interact with your Cortex cluster.
 
 ### `prepare`
 Prepares a rules file(s) for upload to Cortex. It lints all your PromQL expressions and adds a `cluster` label to your PromQL query aggregations in the file. Prepare modifies the file(s) in-place. Does not interact with your Cortex cluster.

--- a/action.yaml
+++ b/action.yaml
@@ -1,14 +1,14 @@
 name: cortextool-sync
 author: jtlisi
-description: "Sync/Diff Prometheus Rules files to with a Cortex cluster."
+description: "A set of actions to interact with Prometheus Rules files and a Cortex cluster."
 runs:
   using: "docker"
   image: "Dockerfile"
 outputs:
   summary:
-    description: A summary of changes that will be made if the provided rules are synced.
+    description: A summary of changes that will be made.
   detailed:
-    description: A detailed description of changes that will be made if the provided rules are synced.
+    description: A detailed description of changes that will be made.
 branding:
   icon: "upload"  
   color: "blue"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,38 +1,62 @@
 #!/bin/sh
 #
-# Sync/Diff rules to a Cortex cluster using the cortex tool
+# Interact with the Cortex Ruler API using the cortextool
 
 err() {
   echo "[$(date +'%Y-%m-%dT%H:%M:%S%z')]: " + "$@" >&2
 }
 
+# For commands that interact with the server, we need to verify that the
+# CORTEX_TENANT_ID and CORTEX_ADDRESS are set.
+verifyTenantAndAddress() {
+  if [ -z "${CORTEX_TENANT_ID}" ]; then
+    err "CORTEX_TENANT_ID has not been set."
+    exit 1
+  fi
+
+  if [ -z "${CORTEX_ADDRESS}" ]; then
+    err "CORTEX_ADDRESS has not been set."
+    exit 1
+  fi
+}
+
+LINT_CMD=lint
+CHECK_CMD=check
+PREPARE_CMD=prepare
+SYNC_CMD=sync
+DIFF_CMD=diff
 
 if [ -z "${RULES_DIR}" ]; then
+  echo "RULES_DIR not set, using './' as a default."
   RULES_DIR="./"
 fi
 
 if [ -z "${ACTION}" ]; then
-  ACTION="diff"
-fi
-
-if [ -z "${CORTEX_TENANT_ID}" ]; then
-  err "CORTEX_TENANT_ID has not been set."
+  err "ACTION has not been set."
   exit 1
 fi
-
-if [ -z "${CORTEX_ADDRESS}" ]; then
-  err "CORTEX_ADDRESS has not been set."
-  exit 1
-fi
-
 
 case "${ACTION}" in
-  sync)
+  $SYNC_CMD)
+    verifyTenantAndAddress
     OUTPUT=$(/usr/bin/cortextool rules sync --rule-dirs="${RULES_DIR}")
     STATUS=$?
     ;;
-  diff)
+  $DIFF_CMD)
+    verifyTenantAndAddress
     OUTPUT=$(/usr/bin/cortextool rules diff --rule-dirs="${RULES_DIR}")
+    STATUS=$?
+    ;;
+  $LINT_CMD)
+    OUTPUT=$(/usr/bin/cortextool rules lint --rule-dirs="${RULES_DIR}")
+    STATUS=$?
+    ;;
+  $PREPARE_CMD)
+    OUTPUT=$(/usr/bin/cortextool rules prepare -i --rule-dirs="${RULES_DIR}")
+    STATUS=$?
+    ;;
+  $CHECK_CMD)
+    OUTPUT=$(/usr/bin/cortextool rules check --rule-dirs="${RULES_DIR}")
     STATUS=$?
     ;;
   *)


### PR DESCRIPTION
This PR includes the addition of several commands to the GitHub action. Most of them are already described in the readme itself, so I'm going to avoid repeating myself here.

Given we now have more than two commands (previously only diff/sync), I have removed wording around the README that hinted only those two making it a bit more generic. 