### PR TITLE
Loki support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM owend/cortextool:loki-loading-012153a
+FROM grafana/cortex-tools:v0.3.0
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM grafana/cortextool:v0.2.2
+FROM owend/cortextool:loki-loading-012153a
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,11 @@ Prepares a rules file(s) for upload to Cortex. It lints all your PromQL expressi
 
 ### `check`
 
-Checks rules fuile(s) against the recommended [best practices](https://prometheus.io/docs/practices/rules/) for rules. Does not interact with your Cortex cluster.
+Checks rules file(s) against the recommended [best practices](https://prometheus.io/docs/practices/rules/) for rules. Does not interact with your Cortex cluster.
+
+### `print`
+
+fetch & print rules from the Cortex cluster.
 
 ## Outputs
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,6 +25,7 @@ CHECK_CMD=check
 PREPARE_CMD=prepare
 SYNC_CMD=sync
 DIFF_CMD=diff
+PRINT_CMD=print
 
 if [ -z "${RULES_DIR}" ]; then
   echo "RULES_DIR not set, using './' as a default."
@@ -59,6 +60,10 @@ case "${ACTION}" in
     OUTPUT=$(/usr/bin/cortextool rules check --rule-dirs="${RULES_DIR}" "$@")
     STATUS=$?
     ;;
+  $PRINT_CMD)
+      OUTPUT=$(/usr/bin/cortextool rules print "$@")
+      STATUS=$?
+      ;;
   *)
     err "Unexpected action '${ACTION}'"
     exit 1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -39,24 +39,24 @@ fi
 case "${ACTION}" in
   $SYNC_CMD)
     verifyTenantAndAddress
-    OUTPUT=$(/usr/bin/cortextool rules sync --rule-dirs="${RULES_DIR}")
+    OUTPUT=$(/usr/bin/cortextool rules sync --rule-dirs="${RULES_DIR}" "$@")
     STATUS=$?
     ;;
   $DIFF_CMD)
     verifyTenantAndAddress
-    OUTPUT=$(/usr/bin/cortextool rules diff --rule-dirs="${RULES_DIR}")
+    OUTPUT=$(/usr/bin/cortextool rules diff --rule-dirs="${RULES_DIR}" "$@")
     STATUS=$?
     ;;
   $LINT_CMD)
-    OUTPUT=$(/usr/bin/cortextool rules lint --rule-dirs="${RULES_DIR}")
+    OUTPUT=$(/usr/bin/cortextool rules lint --rule-dirs="${RULES_DIR}" "$@")
     STATUS=$?
     ;;
   $PREPARE_CMD)
-    OUTPUT=$(/usr/bin/cortextool rules prepare -i --rule-dirs="${RULES_DIR}")
+    OUTPUT=$(/usr/bin/cortextool rules prepare -i --rule-dirs="${RULES_DIR}" "$@")
     STATUS=$?
     ;;
   $CHECK_CMD)
-    OUTPUT=$(/usr/bin/cortextool rules check --rule-dirs="${RULES_DIR}")
+    OUTPUT=$(/usr/bin/cortextool rules check --rule-dirs="${RULES_DIR}" "$@")
     STATUS=$?
     ;;
   *)


### PR DESCRIPTION
## What

- Supports `rules print` command
- Supports arbitrary argument passing, allowing usage like
```
      - name: Check Loki Rules
        uses: grafana/cortex-rules-action@loki-action
        env:
          RULES_DIR: 'output/loki'
          ACTION: 'check'
        with:
          args: --backend=loki
```
- Supports Loki 

## TODO:

- [x] replace with an updated tag from `grafana/cortextool` instead of a custom build once we've sufficiently integration tested the new master builds over there.