### PR TITLE
Update Dockerfile to use v0.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM grafana/cortextool:v0.2.2
+FROM grafana/cortextool:v0.3.0
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
The latest version of cortextool has some critical dependency updates which we need. 