### PR TITLE
Disable output coloring

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -45,7 +45,7 @@ case "${ACTION}" in
     ;;
   $DIFF_CMD)
     verifyTenantAndAddress
-    OUTPUT=$(/usr/bin/cortextool rules diff --rule-dirs="${RULES_DIR}" "$@")
+    OUTPUT=$(/usr/bin/cortextool rules diff --rule-dirs="${RULES_DIR}" --disable-color "$@")
     STATUS=$?
     ;;
   $LINT_CMD)
@@ -61,7 +61,7 @@ case "${ACTION}" in
     STATUS=$?
     ;;
   $PRINT_CMD)
-      OUTPUT=$(/usr/bin/cortextool rules print "$@")
+      OUTPUT=$(/usr/bin/cortextool rules print --disable-color "$@")
       STATUS=$?
       ;;
   *)


### PR DESCRIPTION
We found out an issue with `cortextool rules print` which hungs while printing the output when output coloring is enabled. To unblock the action, in this PR I'm proposing to disable output coloring.