### PR TITLE
Replace newlines with `awk`.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,4 +6,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: azohra/shell-linter@latest
+    - uses: azohra/shell-linter@v0.6.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,9 @@
+name: Lint Scripts
+on: [pull_request]
+jobs:
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: azohra/shell-linter@latest

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -71,7 +71,7 @@ case "${ACTION}" in
     ;;
 esac
 
-SINGLE_LINE_OUTPUT=$(echo "${OUTPUT}" | awk 'BEGIN {RS=""}{gsub(/%/,"%25") gsub(/\r/, "%0D") gsub(/\n/, "%0A")}1')
+SINGLE_LINE_OUTPUT=$(echo "${OUTPUT}" | awk 'BEGIN {RS=""}{gsub(/%/,"%25"); gsub(/\r/, "%0D"); gsub(/\n/, "%0A"); print $0}')
 echo ::set-output name=detailed::"${SINGLE_LINE_OUTPUT}"
 SUMMARY=$(echo "${OUTPUT}" | grep Summary)
 echo ::set-output name=summary::"${SUMMARY}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -71,7 +71,7 @@ case "${ACTION}" in
     ;;
 esac
 
-SINGLE_LINE_OUTPUT=$(echo "${OUTPUT}" | awk 'BEGIN {RS=""}{gsub(/%/,"%25"); gsub(/\r/, "%0D"); gsub(/\n/, "%0A"); print $0}')
+SINGLE_LINE_OUTPUT=$(echo "${OUTPUT}" | awk 'BEGIN { RS="" } { gsub(/%/, "%25"); gsub(/\r/, "%0D"); gsub(/\n/, "%0A") } { print }')
 echo ::set-output name=detailed::"${SINGLE_LINE_OUTPUT}"
 SUMMARY=$(echo "${OUTPUT}" | grep Summary)
 echo ::set-output name=summary::"${SUMMARY}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# shellcheck shell=dash
 #
 # Interact with the Cortex Ruler API using the cortextool
 
@@ -24,7 +25,7 @@ LINT_CMD=lint
 CHECK_CMD=check
 PREPARE_CMD=prepare
 SYNC_CMD=sync
-DIFF_CMD=diff
+DIFF_CMD="diff"
 PRINT_CMD=print
 
 if [ -z "${RULES_DIR}" ]; then
@@ -38,30 +39,36 @@ if [ -z "${ACTION}" ]; then
 fi
 
 case "${ACTION}" in
-  $SYNC_CMD)
+  "$SYNC_CMD")
     verifyTenantAndAddress
-    OUTPUT=$(/usr/bin/cortextool rules sync --rule-dirs="${RULES_DIR}" ${NAMESPACES:+ --namespaces=${NAMESPACES}} "$@")
+    OUTPUT=$(/usr/bin/cortextool rules sync --rule-dirs="${RULES_DIR}" ${NAMESPACES:+ --namespaces=${NAMESPACES}} "$@" | \
+        awk 'BEGIN {RS=""}{gsub(/\r/, "%0D") gsub(/\n/, "%0A") gsub(/%/,"%25")}1')
     STATUS=$?
     ;;
-  $DIFF_CMD)
+  "$DIFF_CMD")
     verifyTenantAndAddress
-    OUTPUT=$(/usr/bin/cortextool rules diff --rule-dirs="${RULES_DIR}" ${NAMESPACES:+ --namespaces=${NAMESPACES}} --disable-color "$@")
+    OUTPUT=$(/usr/bin/cortextool rules diff --rule-dirs="${RULES_DIR}" ${NAMESPACES:+ --namespaces=${NAMESPACES}} --disable-color "$@" | \
+        awk 'BEGIN {RS=""}{gsub(/\r/, "%0D") gsub(/\n/, "%0A") gsub(/%/,"%25")}1')
     STATUS=$?
     ;;
-  $LINT_CMD)
-    OUTPUT=$(/usr/bin/cortextool rules lint --rule-dirs="${RULES_DIR}" "$@")
+  "$LINT_CMD")
+    OUTPUT=$(/usr/bin/cortextool rules lint --rule-dirs="${RULES_DIR}" "$@" | \
+        awk 'BEGIN {RS=""}{gsub(/\r/, "%0D") gsub(/\n/, "%0A") gsub(/%/,"%25")}1')
     STATUS=$?
     ;;
-  $PREPARE_CMD)
-    OUTPUT=$(/usr/bin/cortextool rules prepare -i --rule-dirs="${RULES_DIR}" --label-excluded-rule-groups="${LABEL_EXCLUDED_RULE_GROUPS}" "$@")
+  "$PREPARE_CMD")
+    OUTPUT=$(/usr/bin/cortextool rules prepare -i --rule-dirs="${RULES_DIR}" --label-excluded-rule-groups="${LABEL_EXCLUDED_RULE_GROUPS}" "$@" | \
+        awk 'BEGIN {RS=""}{gsub(/\r/, "%0D") gsub(/\n/, "%0A") gsub(/%/,"%25")}1')
     STATUS=$?
     ;;
-  $CHECK_CMD)
-    OUTPUT=$(/usr/bin/cortextool rules check --rule-dirs="${RULES_DIR}" "$@")
+  "$CHECK_CMD")
+    OUTPUT=$(/usr/bin/cortextool rules check --rule-dirs="${RULES_DIR}" "$@" | \
+        awk 'BEGIN {RS=""}{gsub(/\r/, "%0D") gsub(/\n/, "%0A") gsub(/%/,"%25")}1')
     STATUS=$?
     ;;
-  $PRINT_CMD)
-      OUTPUT=$(/usr/bin/cortextool rules print --disable-color "$@")
+  "$PRINT_CMD")
+      OUTPUT=$(/usr/bin/cortextool rules print --disable-color "$@" | \
+        awk 'BEGIN {RS=""}{gsub(/\r/, "%0D") gsub(/\n/, "%0A") gsub(/%/,"%25")}1')
       STATUS=$?
       ;;
   *)
@@ -70,11 +77,7 @@ case "${ACTION}" in
     ;;
 esac
 
-echo "${OUTPUT}"
-SINGLE_LINE_OUTPUT="${OUTPUT//'%'/'%25'}"
-SINGLE_LINE_OUTPUT="${SINGLE_LINE_OUTPUT//$'\n'/'%0A'}"
-SINGLE_LINE_OUTPUT="${SINGLE_LINE_OUTPUT//$'\r'/'%0D'}"
-echo ::set-output name=detailed::"${SINGLE_LINE_OUTPUT}"
+echo ::set-output name=detailed::"${OUTPUT}"
 SUMMARY=$(echo "${OUTPUT}" | grep Summary)
 echo ::set-output name=summary::"${SUMMARY}"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,34 +41,28 @@ fi
 case "${ACTION}" in
   "$SYNC_CMD")
     verifyTenantAndAddress
-    OUTPUT=$(/usr/bin/cortextool rules sync --rule-dirs="${RULES_DIR}" ${NAMESPACES:+ --namespaces=${NAMESPACES}} "$@" | \
-        awk 'BEGIN {RS=""}{gsub(/\r/, "%0D") gsub(/\n/, "%0A") gsub(/%/,"%25")}1')
+    OUTPUT=$(/usr/bin/cortextool rules sync --rule-dirs="${RULES_DIR}" ${NAMESPACES:+ --namespaces=${NAMESPACES}} "$@")
     STATUS=$?
     ;;
   "$DIFF_CMD")
     verifyTenantAndAddress
-    OUTPUT=$(/usr/bin/cortextool rules diff --rule-dirs="${RULES_DIR}" ${NAMESPACES:+ --namespaces=${NAMESPACES}} --disable-color "$@" | \
-        awk 'BEGIN {RS=""}{gsub(/\r/, "%0D") gsub(/\n/, "%0A") gsub(/%/,"%25")}1')
+    OUTPUT=$(/usr/bin/cortextool rules diff --rule-dirs="${RULES_DIR}" ${NAMESPACES:+ --namespaces=${NAMESPACES}} --disable-color "$@")
     STATUS=$?
     ;;
   "$LINT_CMD")
-    OUTPUT=$(/usr/bin/cortextool rules lint --rule-dirs="${RULES_DIR}" "$@" | \
-        awk 'BEGIN {RS=""}{gsub(/\r/, "%0D") gsub(/\n/, "%0A") gsub(/%/,"%25")}1')
+    OUTPUT=$(/usr/bin/cortextool rules lint --rule-dirs="${RULES_DIR}" "$@")
     STATUS=$?
     ;;
   "$PREPARE_CMD")
-    OUTPUT=$(/usr/bin/cortextool rules prepare -i --rule-dirs="${RULES_DIR}" --label-excluded-rule-groups="${LABEL_EXCLUDED_RULE_GROUPS}" "$@" | \
-        awk 'BEGIN {RS=""}{gsub(/\r/, "%0D") gsub(/\n/, "%0A") gsub(/%/,"%25")}1')
+    OUTPUT=$(/usr/bin/cortextool rules prepare -i --rule-dirs="${RULES_DIR}" --label-excluded-rule-groups="${LABEL_EXCLUDED_RULE_GROUPS}" "$@")
     STATUS=$?
     ;;
   "$CHECK_CMD")
-    OUTPUT=$(/usr/bin/cortextool rules check --rule-dirs="${RULES_DIR}" "$@" | \
-        awk 'BEGIN {RS=""}{gsub(/\r/, "%0D") gsub(/\n/, "%0A") gsub(/%/,"%25")}1')
+    OUTPUT=$(/usr/bin/cortextool rules check --rule-dirs="${RULES_DIR}" "$@")
     STATUS=$?
     ;;
   "$PRINT_CMD")
-      OUTPUT=$(/usr/bin/cortextool rules print --disable-color "$@" | \
-        awk 'BEGIN {RS=""}{gsub(/\r/, "%0D") gsub(/\n/, "%0A") gsub(/%/,"%25")}1')
+      OUTPUT=$(/usr/bin/cortextool rules print --disable-color "$@")
       STATUS=$?
       ;;
   *)
@@ -77,7 +71,8 @@ case "${ACTION}" in
     ;;
 esac
 
-echo ::set-output name=detailed::"${OUTPUT}"
+SINGLE_LINE_OUTPUT=$(echo "${OUTPUT}" | awk 'BEGIN {RS=""}{gsub(/%/,"%25") gsub(/\r/, "%0D") gsub(/\n/, "%0A")}1')
+echo ::set-output name=detailed::"${SINGLE_LINE_OUTPUT}"
 SUMMARY=$(echo "${OUTPUT}" | grep Summary)
 echo ::set-output name=summary::"${SUMMARY}"
 


### PR DESCRIPTION
Summary:
- #16 introduced a bug. The `entrypoint.sh` was not compatible with ash.
- Replace Bash string replacement with `awk`.

Closes #19