### PR TITLE
chore: replace deprecated set-output method with GITHUB_OUTPUT

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -77,8 +77,8 @@ case "${ACTION}" in
 esac
 
 SINGLE_LINE_OUTPUT=$(echo "${OUTPUT}" | awk 'BEGIN { RS="" } { gsub(/%/, "%25"); gsub(/\r/, "%0D"); gsub(/\n/, "%0A") } { print }')
-echo "detailed=${SINGLE_LINE_OUTPUT}" >> $GITHUB_OUTPUT
+echo "detailed=${SINGLE_LINE_OUTPUT}" >> "$GITHUB_OUTPUT"
 SUMMARY=$(echo "${OUTPUT}" | grep Summary)
-echo "summary=${SUMMARY}" >> $GITHUB_OUTPUT
+echo "summary=${SUMMARY}" >> "$GITHUB_OUTPUT"
 
 exit $STATUS

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -77,8 +77,8 @@ case "${ACTION}" in
 esac
 
 SINGLE_LINE_OUTPUT=$(echo "${OUTPUT}" | awk 'BEGIN { RS="" } { gsub(/%/, "%25"); gsub(/\r/, "%0D"); gsub(/\n/, "%0A") } { print }')
-echo ::set-output name=detailed::"${SINGLE_LINE_OUTPUT}"
+echo "detailed=${SINGLE_LINE_OUTPUT}" >> $GITHUB_OUTPUT
 SUMMARY=$(echo "${OUTPUT}" | grep Summary)
-echo ::set-output name=summary::"${SUMMARY}"
+echo "summary=${SUMMARY}" >> $GITHUB_OUTPUT
 
 exit $STATUS


### PR DESCRIPTION
Hey folks 👋

Small PR that update the method to set the output of the action

This has been done following https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Don't hesitate to ping me if any remarks/questions 😉 ?

Cheers ☀️