### PR TITLE
fix: multiline output

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -76,8 +76,8 @@ case "${ACTION}" in
     ;;
 esac
 
-SINGLE_LINE_OUTPUT=$(echo "${OUTPUT}" | awk 'BEGIN { RS="" } { gsub(/%/, "%25"); gsub(/\r/, "%0D"); gsub(/\n/, "%0A") } { print }')
-echo "detailed=${SINGLE_LINE_OUTPUT}" >> "$GITHUB_OUTPUT"
+{ echo "detailed<<EOF"; echo "$OUTPUT"; echo "EOF"; } >> "$GITHUB_OUTPUT"
+
 SUMMARY=$(echo "${OUTPUT}" | grep Summary)
 echo "summary=${SUMMARY}" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
Hey folks 👋

Small PR that fix/simplify the way the multiline is rendered in the output of the action

With the following pipeline
```
name: loki_rules_ci
on:
  workflow_dispatch:
  pull_request:
jobs:
  loki_rules:
    name: Check Loki Rules
    runs-on: ubuntu-latest
    steps:
      - name: Checkout
        uses: actions/checkout@v4
      - name: Check Loki rules
        uses: rasta-rocket/cortex-rules-action@fix_multiline
        env:
          CORTEX_ADDRESS: "xxxxxx"
          CORTEX_TENANT_ID: xxxxx
          BACKEND: loki
          ACTION: check
          RULES_DIR: "./loki/alert,./loki/record"
      - name: Diff Loki rules
        id: diff_rules
        uses: rasta-rocket/cortex-rules-action@fix_multiline
        env:
          CORTEX_ADDRESS: "xxxxxxx"
          CORTEX_TENANT_ID: xxxxx
          BACKEND: loki
          ACTION: diff
          RULES_DIR: "./loki/alert,./loki/record"
      - name: Put diff in summary
        run: |
           echo "${{ steps.diff_rules.outputs.detailed }}"

           echo '# Diff summary' >> $GITHUB_STEP_SUMMARY
           echo '```diff' >> $GITHUB_STEP_SUMMARY
           echo "${{ steps.diff_rules.outputs.detailed }}" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
```

Before the fix:
<img width="1036" alt="image" src="https://github.com/user-attachments/assets/ccfcf144-073e-4907-803a-4fdc41849435">

After the fix:
<img width="1039" alt="image" src="https://github.com/user-attachments/assets/4bab1938-aa64-47e5-85b3-b68d4f48bcff">

This has been done following :
- https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-a-multiline-string
- https://til.juliusgamanyi.com/posts/gh-actions-save-multiline-string-in-output-var/

Don't hesitate to ping me if any remarks/questions 😉 ?

Cheers ☀️