### PR TITLE
Bump cortextool to v0.11.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM grafana/cortex-tools:v0.11.2
+FROM grafana/cortex-tools:v0.11.3
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
Updates cortex-tools to [v0.11.3](https://github.com/grafana/cortex-tools/releases/tag/v0.11.3) ([docker hub](https://hub.docker.com/layers/grafana/cortex-tools/v0.11.3/images/sha256-ed86004a3d5eb7a8351fd1fa9c2a8f4f70c6b133eb57846c55aef9e4f485da0c))